### PR TITLE
Adapt OpenCV4

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ I write a python wrapper for [KCFcpp](https://github.com/joaofaro/KCFcpp), some 
 Requirements
 -----
 * Python 2.7
+* pkgconfig Python package
 * NumPy
 * Cython
 * OpenCV (both C++ and Python interfaces)

--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,32 @@
+import sys
 from distutils.core import setup, Extension
 from Cython.Distutils import build_ext
 import numpy
+import pkgconfig
 
-libdr = ['/usr/local/lib']
-incdr = [numpy.get_include(), '/usr/local/include/']
+if pkgconfig.exists('opencv4'):
+	opencv_pkginfo = pkgconfig.parse('opencv4')
+	extra_compile_args = ['-std=c++11', '-DUSE_OPENCV4']
+elif pkgconfig.exists('opencv'):
+	opencv_pkginfo = pkgconfig.parse('opencv')
+	extra_compile_args = ['-std=c++11']
+else:
+	print("opencv package config is not found.", file=sys.stderr)
+	exit(1)
+
+libdr = ['/usr/local/lib'] + opencv_pkginfo["library_dirs"]
+incdr = [numpy.get_include(), '/usr/local/include/'] + opencv_pkginfo["include_dirs"]
 
 ext = [
 	Extension('cvt', ['python/cvt.pyx'], 
 		language = 'c++', 
-		extra_compile_args = ['-std=c++11'], 
+		extra_compile_args = extra_compile_args,
 		include_dirs = incdr, 
 		library_dirs = libdr, 
 		libraries = ['opencv_core']), 
 	Extension('KCF', ['python/KCF.pyx', 'src/kcftracker.cpp', 'src/fhog.cpp'], 
 		language = 'c++', 
-		extra_compile_args = ['-std=c++11'], 
+		extra_compile_args = extra_compile_args,
 		include_dirs = incdr, 
 		library_dirs = libdr, 
 		libraries = ['opencv_core', 'opencv_imgproc'])

--- a/src/kcftracker.cpp
+++ b/src/kcftracker.cpp
@@ -403,7 +403,11 @@ cv::Mat KCFTracker::getFeatures(const cv::Mat & image, bool inithann, float scal
 
     // HOG features
     if (_hogfeatures) {
+#ifdef USE_OPENCV4
+        IplImage z_ipl = cvIplImage(z);
+#else
         IplImage z_ipl = z;
+#endif
         CvLSVMFeatureMapCaskade *map;
         getFeatureMaps(&z_ipl, cell_size, &map);
         normalizeAndTruncate(map,0.2f);

--- a/src/tracker.h
+++ b/src/tracker.h
@@ -21,6 +21,10 @@
 #include <opencv2/opencv.hpp>
 #include <string>
 
+#ifdef USE_OPENCV4
+#include <opencv2/imgproc/types_c.h> // for CV_BGR2GRAY constant
+#endif
+
 class Tracker
 {
 public:


### PR DESCRIPTION
This PR enables to compile KCFcpp-py-wrapper with OpenCV4 environment.

I guess it does not disrupt OpenCV3.x setup.
